### PR TITLE
Update Node to 14.17.4 (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.1
+FROM node:14.17.4
 
 LABEL com.github.actions.name="ESLint Action"
 LABEL com.github.actions.description="Lint your Javascript projects with inline lint error annotations on pull requests."


### PR DESCRIPTION
This action started failing because of some package that depends on [Node 14.17](https://nodejs.org/en/blog/release/v14.17.4/).

See the discussion in https://github.com/gnosis/safe-react/pull/2606.