### PR TITLE
update node to 16 lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.4
+FROM node:16.15.1
 
 LABEL com.github.actions.name="ESLint Action"
 LABEL com.github.actions.description="Lint your Javascript projects with inline lint error annotations on pull requests."


### PR DESCRIPTION
in safe apps SDK we started requiring node >= 16, current lts (prev 14, maintenance lts) and the eslint action stopped working because it was using node 14

failed runs - https://github.com/safe-global/safe-apps-sdk/runs/6917243800?check_suite_focus=true
run pointing to this branch - https://github.com/safe-global/safe-apps-sdk/runs/6937049867?check_suite_focus=true